### PR TITLE
2021판 한국어 번역 링크 추가

### DIFF
--- a/content/pages/_index.md
+++ b/content/pages/_index.md
@@ -29,6 +29,7 @@ NOTE: 코딩모임이 열린다면 주석처리된 아래의 코드를 되살리
 
 - [설치하기](/pages/install)
 - [러스트 공식 안내서: "The Rust Programming Language"](https://doc.rust-lang.org/book/) (영문)
+  - [2021판 한국어 번역](https://rust-kr.github.io/doc.rust-kr.org/)
   - [2판 한국어 번역](https://rinthel.github.io/rust-lang-book-ko/)
 - ["Rust By Example" 한국어 번역](https://hanbum.gitbooks.io/rustbyexample/content/)
 - ["The Edition Guide" 한국어 번역](https://yegeun542.github.io/rust-edition-guide-ko/)


### PR DESCRIPTION
안녕하세요 the book 번역을 관리하는 rinthel입니다 😄
어제부로 2021판 한국어 번역이 (아직은 draft 상태이지만) 완료되었습니다.
한국 러스트 사용자 모임 페이지를 보니, 여전히 제 개인 github으로 연결되는 2판 번역 링크만 있어서, 링크를 추가하는 PR을 올려둡니다-