### PR TITLE
rust 설치 스크립트 수정

### DIFF
--- a/content/pages/install.md
+++ b/content/pages/install.md
@@ -13,7 +13,7 @@ Rust 설치하기
 패키지매니저가 한번에 설치됩니다.
 
 ```bash
-curl https://sh.rustup.rs -sSf | sh -s -- --help
+curl https://sh.rustup.rs -sSf | sh -s
 ```
 
 윈도우의 경우, [rustup‑init.exe] 파일을 받아서 실행하기만 하면 시스템에 Rust가


### PR DESCRIPTION
아래의 기존 스크립트는 설치 스크립트의 도움말을 출력합니다.
`curl https://sh.rustup.rs -sSf | sh -s -- --help`

문서의 설명대로 패키지매니저가 한번에 설치하기 위해 명령행 옵션(--help)을 제거해야 합니다. 
`curl https://sh.rustup.rs -sSf | sh -s`